### PR TITLE
Replaced options.init with options.onrender

### DIFF
--- a/authors.md
+++ b/authors.md
@@ -34,7 +34,7 @@ Components are designed to be completely agnostic about their environment. Use A
   // `component.exports` should basically be what you'd normally use
   // with `Ractive.extend(...)`, except that the template is already specified
   component.exports = {
-    init: function () {
+    onrender: function () {
       alert( 'initing component' );
     },
 
@@ -116,7 +116,7 @@ Much in the same way that node modules have `module.exports`, Ractive components
 
 ```js
 component.exports = {
-  init: function () {
+  onrender: function () {
     alert( 'initing component' );
   },
 


### PR DESCRIPTION
When running Ractive v0.6.1 I get this warning: "Ractive.js: options.init has been deprecated in favour of options.onrender."